### PR TITLE
fix: set hostname to 127.0.0.1 to support node 18.x.x

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,5 @@ export const POLL_TIMEOUT = 10000
 export const DEFAULT_PATH = '/'
 export const LOCAL_OPTIONS = {
     protocol: 'http',
-    hostname: 'localhost'
+    hostname: '127.0.0.1'
 }


### PR DESCRIPTION
in Node 18.x  geckodriver fails to create a session if the hostname is localhost.